### PR TITLE
Track server and protocol version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ const config: MetricsConfig = {
   serverAgent: '@payid-org/payid:1.2.0',
 
   // the maximum PayID protocol version supported by this PayID server
-  payIdProtocolVersion: string,
+  payIdProtocolVersion: 1.0,
 }
 
 // TODO: You must implement your own data-access functions to work with your database.

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,14 @@ const config: MetricsConfig = {
 
   // How frequently (in seconds) to refresh the PayID Count report data from the database
   payIdCountRefreshIntervalInSeconds: 60,
+
+  // (Optional> Identifies the PayID server implementation that's reporting the metrics.
+  // This is similar to the user-agent header for web browsers that helps identify the client software version. 
+  // Recommended format is <library/repo>:<version>
+  serverAgent: '@payid-org/payid:1.0.0',
+
+  // the maximum PayID protocol version supported by this PayID server
+  payIdProtocolVersion: string
 }
 
 // TODO: You must implement your own data-access functions to work with your database.

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ const config: MetricsConfig = {
   // (Optional) Identifies the PayID server implementation that's reporting the metrics.
   // This is similar to the user-agent header for web browsers that helps identify the client software version.
   // Recommended format is <library/repo>:<version>
-  serverAgent: '@payid-org/payid:1.0.0',
+  serverAgent: '@payid-org/payid:1.2.0',
 
   // the maximum PayID protocol version supported by this PayID server
   payIdProtocolVersion: string,

--- a/readme.md
+++ b/readme.md
@@ -34,13 +34,13 @@ const config: MetricsConfig = {
   // How frequently (in seconds) to refresh the PayID Count report data from the database
   payIdCountRefreshIntervalInSeconds: 60,
 
-  // (Optional> Identifies the PayID server implementation that's reporting the metrics.
-  // This is similar to the user-agent header for web browsers that helps identify the client software version. 
+  // (Optional) Identifies the PayID server implementation that's reporting the metrics.
+  // This is similar to the user-agent header for web browsers that helps identify the client software version.
   // Recommended format is <library/repo>:<version>
   serverAgent: '@payid-org/payid:1.0.0',
 
   // the maximum PayID protocol version supported by this PayID server
-  payIdProtocolVersion: string
+  payIdProtocolVersion: string,
 }
 
 // TODO: You must implement your own data-access functions to work with your database.

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -295,6 +295,9 @@ export default class Metrics {
     )
   }
 
+  /**
+   * Updates the serverInfoGauge with the current configuration.
+   */
   private updateInfoGauge(): void {
     const serverAgent = this.config.serverAgent ?? 'unknown'
     const protocolVersion = this.config.payIdProtocolVersion

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -34,6 +34,11 @@ export default class Metrics {
   /** Prometheus Gauge for reporting the current count of PayIDs by org. */
   private readonly payIdGauge: Gauge<'org'>
 
+  /** Prometheus Gauge for reporting the current count of PayIDs by org. */
+  private readonly serverInfoGauge: Gauge<
+    'org' | 'serverAgent' | 'protocolVersion'
+  >
+
   // These are Timeouts for generating metrics on a recurring basis.
   // To shut down the app properly, we need to clean these up as we shut down.
   private recurringMetricsPushTimeout?: NodeJS.Timeout
@@ -83,6 +88,13 @@ export default class Metrics {
       name: 'actual_payid_count',
       help: 'count of total PayIDs',
       labelNames: ['org'],
+      registers: [this.payIdGaugeRegistry],
+    })
+
+    this.serverInfoGauge = new Gauge({
+      name: 'payid_server_info',
+      help: 'version information for server',
+      labelNames: ['org', 'serverAgent', 'protocolVersion'],
       registers: [this.payIdGaugeRegistry],
     })
   }
@@ -175,6 +187,8 @@ export default class Metrics {
     this.generatePayIdCountMetrics().catch((err) =>
       logger.warn('Failed to generate initial PayID count metrics', err),
     )
+
+    this.updateInfoGauge()
 
     this.recurringMetricsTimeout = setInterval(() => {
       this.generateAddressCountMetrics().catch((err) =>
@@ -278,6 +292,19 @@ export default class Metrics {
         org: this.config.domain,
       },
       payIdCount,
+    )
+  }
+
+  private updateInfoGauge(): void {
+    const serverAgent = this.config.serverAgent ?? 'unknown'
+    const protocolVersion = this.config.payIdProtocolVersion
+    this.serverInfoGauge.set(
+      {
+        org: this.config.domain,
+        serverAgent,
+        protocolVersion,
+      },
+      1,
     )
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,4 +16,8 @@ export interface MetricsConfig {
   readonly gatewayUrl: string
   readonly pushIntervalInSeconds: number
   readonly payIdCountRefreshIntervalInSeconds: number
+  // serverAgent is an optional field to identify the PayID server implementation that's reporting the metrics.
+  // For example the PayID reference implementation sets this like @payid-org/payid:1.0.0
+  readonly serverAgent?: string
+  readonly payIdProtocolVersion: string
 }

--- a/test/config.ts
+++ b/test/config.ts
@@ -18,7 +18,7 @@ const config = {
   payIdCountRefreshIntervalInSeconds: 60,
 
   // protocol version (i.e. what PayID-Version is supported)
-  payIdProtocolVersion: '1.0.0',
+  payIdProtocolVersion: '1.0',
 
   serverAgent: 'unittest:1.2.3',
 }

--- a/test/config.ts
+++ b/test/config.ts
@@ -16,6 +16,11 @@ const config = {
 
   // How frequently (in seconds) to refresh the PayID Count report data from the database
   payIdCountRefreshIntervalInSeconds: 60,
+
+  // protocol version (i.e. what PayID-Version is supported)
+  payIdProtocolVersion: '1.0.0',
+
+  serverAgent: 'unittest:1.2.3',
 }
 
 export default config

--- a/test/scheduleRecurringMetricsGeneration.test.ts
+++ b/test/scheduleRecurringMetricsGeneration.test.ts
@@ -1,0 +1,78 @@
+import 'mocha'
+import { assert } from 'chai'
+
+import { AddressCount, Metrics } from '../src'
+
+import config from './config'
+import structuredClone from './helpers'
+
+let metrics: Metrics
+
+describe('Push Metrics - scheduleRecurringMetricsGeneration()', function (): void {
+  afterEach('', function () {
+    metrics.stopMetrics()
+  })
+
+  it('publishes all gauges', async function () {
+    const expectedPayIdCount = 5
+    const expectedBtcAddressCount = 3
+    const expectedXrpAddressCount = 4
+    const metricsConfig = structuredClone(config)
+    const addressCountFn = async (): Promise<AddressCount[]> => {
+      return [
+        {
+          paymentNetwork: 'BTC',
+          environment: 'MAINNET',
+          count: expectedBtcAddressCount,
+        },
+        {
+          paymentNetwork: 'XRPL',
+          environment: 'MAINNET',
+          count: expectedXrpAddressCount,
+        },
+      ]
+    }
+
+    const payIdCountFn = async (): Promise<number> => expectedPayIdCount
+
+    metrics = new Metrics(metricsConfig, addressCountFn, payIdCountFn)
+    await metrics.generateAddressCountMetrics()
+    await metrics.generatePayIdCountMetrics()
+    metrics.scheduleRecurringMetricsGeneration()
+
+    assertMetrics(
+      /payid_server_info\{org="example.com",serverAgent="unittest:1.2.3",protocolVersion="1.0.0"\} 1/u,
+    )
+
+    assertMetrics(
+      new RegExp(
+        `actual_payid_count\\{org="example.com"\\} ${expectedPayIdCount}`,
+        'u',
+      ),
+    )
+
+    assertMetrics(
+      new RegExp(
+        `payid_count\\{paymentNetwork="XRPL",environment="MAINNET",org="example.com"\\} ${expectedXrpAddressCount}`,
+        'u',
+      ),
+    )
+
+    assertMetrics(
+      new RegExp(
+        `payid_count\\{paymentNetwork="BTC",environment="MAINNET",org="example.com"\\} ${expectedBtcAddressCount}`,
+        'u',
+      ),
+    )
+  })
+})
+
+/**
+ * A helper function that fetches PayID metrics and matches them against
+ * expected metrics.
+ *
+ * @param expectedMetric - The expected metric to match on.
+ */
+function assertMetrics(expectedMetric: RegExp): void {
+  assert.match(metrics.getMetrics(), expectedMetric)
+}

--- a/test/scheduleRecurringMetricsGeneration.test.ts
+++ b/test/scheduleRecurringMetricsGeneration.test.ts
@@ -13,7 +13,7 @@ describe('Push Metrics - scheduleRecurringMetricsGeneration()', function (): voi
     metrics.stopMetrics()
   })
 
-  it('publishes all gauges when provide valid functions', async function () {
+  it('publishes all gauges if provided valid functions', async function () {
     const expectedPayIdCount = 5
     const expectedBtcAddressCount = 3
     const expectedXrpAddressCount = 4

--- a/test/scheduleRecurringMetricsGeneration.test.ts
+++ b/test/scheduleRecurringMetricsGeneration.test.ts
@@ -13,7 +13,7 @@ describe('Push Metrics - scheduleRecurringMetricsGeneration()', function (): voi
     metrics.stopMetrics()
   })
 
-  it('publishes all gauges if provided valid functions', async function () {
+  it('publishes all gauges when provided valid functions', async function () {
     const expectedPayIdCount = 5
     const expectedBtcAddressCount = 3
     const expectedXrpAddressCount = 4

--- a/test/scheduleRecurringMetricsGeneration.test.ts
+++ b/test/scheduleRecurringMetricsGeneration.test.ts
@@ -41,7 +41,7 @@ describe('Push Metrics - scheduleRecurringMetricsGeneration()', function (): voi
     metrics.scheduleRecurringMetricsGeneration()
 
     assertMetrics(
-      /payid_server_info\{org="example.com",serverAgent="unittest:1.2.3",protocolVersion="1.0.0"\} 1/u,
+      /payid_server_info\{org="example.com",serverAgent="unittest:1.2.3",protocolVersion="1.0"\} 1/u,
     )
 
     assertMetrics(

--- a/test/scheduleRecurringMetricsGeneration.test.ts
+++ b/test/scheduleRecurringMetricsGeneration.test.ts
@@ -13,7 +13,7 @@ describe('Push Metrics - scheduleRecurringMetricsGeneration()', function (): voi
     metrics.stopMetrics()
   })
 
-  it('publishes all gauges', async function () {
+  it('publishes all gauges when provide valid functions', async function () {
     const expectedPayIdCount = 5
     const expectedBtcAddressCount = 3
     const expectedXrpAddressCount = 4


### PR DESCRIPTION
## High Level Overview of Change

Publishes a new gauge called "payid_server_info" that contains the serverAgent and payidProtocolVersion

### Context of Change

This will allow the server and protocol versions to be tracked within the metrics platform,

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

internal change to the metrics class

## Test Plan

unit tests were added to verify the gauge populates correctly
manually tested using the PayID reference implementation with local Prometheus pushgateway

<!--
## Future Tasks
For future tasks related to PR.
-->
